### PR TITLE
Adds Specification Pattern Using Expressions

### DIFF
--- a/Specification Pattern.sln
+++ b/Specification Pattern.sln
@@ -1,0 +1,56 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7A1E2AE0-4909-4E08-953F-50034FDACE86}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BkG.SpecificationPattern", "src\BkG.SpecificationPattern\BkG.SpecificationPattern.csproj", "{0286E3F7-EE99-4251-8502-23BF5693C452}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{D24842E5-A1E1-471B-9A29-0DFF06EB8FEB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BkG.SpecificationPattern.Tests", "tests\BkG.SpecificationPattern.Tests\BkG.SpecificationPattern.Tests.csproj", "{1379906D-D140-45D9-8092-E50C1583E2F6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|x64.ActiveCfg = Debug|x64
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|x64.Build.0 = Debug|x64
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|x86.ActiveCfg = Debug|x86
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Debug|x86.Build.0 = Debug|x86
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|x64.ActiveCfg = Release|x64
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|x64.Build.0 = Release|x64
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|x86.ActiveCfg = Release|x86
+		{0286E3F7-EE99-4251-8502-23BF5693C452}.Release|x86.Build.0 = Release|x86
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|x64.ActiveCfg = Debug|x64
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|x64.Build.0 = Debug|x64
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|x86.ActiveCfg = Debug|x86
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Debug|x86.Build.0 = Debug|x86
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|x64.ActiveCfg = Release|x64
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|x64.Build.0 = Release|x64
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|x86.ActiveCfg = Release|x86
+		{1379906D-D140-45D9-8092-E50C1583E2F6}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0286E3F7-EE99-4251-8502-23BF5693C452} = {7A1E2AE0-4909-4E08-953F-50034FDACE86}
+		{1379906D-D140-45D9-8092-E50C1583E2F6} = {D24842E5-A1E1-471B-9A29-0DFF06EB8FEB}
+	EndGlobalSection
+EndGlobal

--- a/src/BkG.SpecificationPattern/BkG.SpecificationPattern.csproj
+++ b/src/BkG.SpecificationPattern/BkG.SpecificationPattern.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/src/BkG.SpecificationPattern/RequiredArgumentNullException.cs
+++ b/src/BkG.SpecificationPattern/RequiredArgumentNullException.cs
@@ -1,0 +1,28 @@
+namespace BkG.SpecificationPattern
+{
+    using System;
+    using System.Runtime.Serialization;
+
+    public class RequiredArgumentNullException : ArgumentNullException
+    {
+        public RequiredArgumentNullException()
+        {
+        }
+
+        public RequiredArgumentNullException(string paramName) : base(paramName)
+        {
+        }
+
+        public RequiredArgumentNullException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        public RequiredArgumentNullException(string paramName, string message) : base(paramName, message)
+        {
+        }
+
+        protected RequiredArgumentNullException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -1,0 +1,16 @@
+namespace BkG.SpecificationPattern
+{
+    using System;
+    using System.Linq.Expressions;
+
+    public sealed class Specification<T>
+    {
+        public Specification(Expression<Func<T, bool>> restriction)
+        {
+            _restriction = restriction 
+                            ?? throw new RequiredArgumentNullException(nameof(restriction), "The specification requires knowing what condition is to be met.");
+        }
+        
+        private readonly Expression<Func<T, bool>> _restriction;
+    }
+}

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -7,7 +7,7 @@ namespace BkG.SpecificationPattern
     {
         public Specification(Expression<Func<T, bool>> restriction)
         {
-            _restriction = restriction 
+            _restriction = restriction
                             ?? throw new RequiredArgumentNullException(nameof(restriction), "The specification requires knowing what condition is to be met.");
         }
 
@@ -19,9 +19,24 @@ namespace BkG.SpecificationPattern
             new Specification<T>(
                 Expression.Lambda<Func<T, bool>>(Expression.Not(_restriction.Body), _restriction.Parameters));
 
-        public static Specification<T> operator !(Specification<T> specification) => 
+        public static Specification<T> operator !(Specification<T> specification) =>
             specification?.Not() ?? throw new RequiredArgumentNullException(nameof(specification), "Negating specification requires non-null reference");
-        
+
+        public Specification<T> And(Specification<T> other) => 
+            other != null
+                    ? DoBinaryOperation(this, other, ExpressionType.AndAlso)
+                    : throw new RequiredArgumentNullException(nameof(other), "The other operand for an And statement cannot be null");
+
+        public static Specification<T> operator &(Specification<T> specification, Specification<T> other) =>
+            specification?.And(other) ?? throw new RequiredArgumentNullException(nameof(specification), "The first operand for an And statement cannot be null");
+
+        private Specification<T> DoBinaryOperation(Specification<T> left, Specification<T> right, ExpressionType expressionType)
+        {
+            var vRightInvoked = Expression.Invoke(right._restriction, left._restriction.Parameters);
+            var vBinaryExpression = Expression.MakeBinary(expressionType, left._restriction.Body, vRightInvoked);
+            return new Specification<T>(Expression.Lambda<Func<T, bool>>(vBinaryExpression, left._restriction.Parameters));
+        }
+
         private readonly Expression<Func<T, bool>> _restriction;
     }
 }

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -30,6 +30,14 @@ namespace BkG.SpecificationPattern
         public static Specification<T> operator &(Specification<T> specification, Specification<T> other) =>
             specification?.And(other) ?? throw new RequiredArgumentNullException(nameof(specification), "The first operand for an And statement cannot be null");
 
+        public Specification<T> Or(Specification<T> other) => 
+            other != null
+                    ? DoBinaryOperation(this, other, ExpressionType.OrElse)
+                    : throw new RequiredArgumentNullException(nameof(other), "The other operand for an Or statement cannot be null");
+
+        public static Specification<T> operator |(Specification<T> specification, Specification<T> other) =>
+            specification?.Or(other) ?? throw new RequiredArgumentNullException(nameof(specification), "The first operand for an Or statement cannot be null");
+
         private Specification<T> DoBinaryOperation(Specification<T> left, Specification<T> right, ExpressionType expressionType)
         {
             var vRightInvoked = Expression.Invoke(right._restriction, left._restriction.Parameters);

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -12,6 +12,8 @@ namespace BkG.SpecificationPattern
         }
 
         public bool IsSatisfiedBy(T current) => _restriction.Compile()(current);
+
+        public static implicit operator Expression<Func<T, bool>>(Specification<T> specification) => specification._restriction;
         
         private readonly Expression<Func<T, bool>> _restriction;
     }

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -14,6 +14,13 @@ namespace BkG.SpecificationPattern
         public bool IsSatisfiedBy(T current) => _restriction.Compile()(current);
 
         public static implicit operator Expression<Func<T, bool>>(Specification<T> specification) => specification._restriction;
+
+        public Specification<T> Not() =>
+            new Specification<T>(
+                Expression.Lambda<Func<T, bool>>(Expression.Not(_restriction.Body), _restriction.Parameters));
+
+        public static Specification<T> operator !(Specification<T> specification) => 
+            specification?.Not() ?? throw new RequiredArgumentNullException(nameof(specification), "Negating specification requires non-null reference");
         
         private readonly Expression<Func<T, bool>> _restriction;
     }

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -10,6 +10,8 @@ namespace BkG.SpecificationPattern
             _restriction = restriction 
                             ?? throw new RequiredArgumentNullException(nameof(restriction), "The specification requires knowing what condition is to be met.");
         }
+
+        public bool IsSatisfiedBy(T current) => _restriction.Compile()(current);
         
         private readonly Expression<Func<T, bool>> _restriction;
     }

--- a/tests/BkG.SpecificationPattern.Tests/BkG.SpecificationPattern.Tests.csproj
+++ b/tests/BkG.SpecificationPattern.Tests/BkG.SpecificationPattern.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BkG.SpecificationPattern\BkG.SpecificationPattern.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/BkG.SpecificationPattern.Tests/Given_A_Required_Argument_Null_Exception.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_A_Required_Argument_Null_Exception.cs
@@ -1,0 +1,17 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BkG.SpecificationPattern.Tests
+{
+    [TestClass]
+    public class Given_A_Required_Argument_Null_Exception
+    {
+        [TestMethod]
+        public void When_The_Exception_Is_Referenced_Then_It_Is_A_Type_Of_Null_Reference_Exception()
+        {
+            var vException = new RequiredArgumentNullException();
+
+            Assert.IsTrue(vException is ArgumentNullException, "The exception should inherit from this type.");
+        }
+    }
+}

--- a/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
@@ -11,5 +11,21 @@ namespace BkG.SpecificationPattern.Tests
         {
             var vSpecification = new Specification<bool>(null);
         }
+
+        [TestMethod]
+        public void When_The_Restriction_Matches_Then_The_Specification_Is_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+
+            Assert.IsTrue(vSpecification.IsSatisfiedBy(true), "Restriction that tests true should satisfy the specification");
+        }
+
+        [TestMethod]
+        public void When_The_Restriction_Does_Not_Match_Then_The_Specification_Is_Not_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+
+            Assert.IsFalse(vSpecification.IsSatisfiedBy(false), "Restriction that tests false should not satisfy the specification");
+        }
     }
 }

--- a/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
@@ -1,0 +1,15 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace BkG.SpecificationPattern.Tests
+{
+    [TestClass]
+    public class Given_A_Single_Specification
+    {
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void When_The_Restriction_Is_Not_Provided_Then_Required_Argument_Null_Exception_Is_Thrown()
+        {
+            var vSpecification = new Specification<bool>(null);
+        }
+    }
+}

--- a/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq.Expressions;
 
 namespace BkG.SpecificationPattern.Tests
 {
@@ -26,6 +28,15 @@ namespace BkG.SpecificationPattern.Tests
             var vSpecification = new Specification<bool>(testValue => testValue);
 
             Assert.IsFalse(vSpecification.IsSatisfiedBy(false), "Restriction that tests false should not satisfy the specification");
+        }
+
+        [TestMethod]
+        public void When_Needed_As_An_Expression_Then_The_Specification_Implicitly_Casts()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+            Expression<Func<bool, bool>> vImplicitCast = vSpecification;
+
+            Assert.IsNotNull(vImplicitCast, "The specificaiton should implicitly cast back to an expression.");
         }
     }
 }

--- a/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification_Is_Negated.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_A_Single_Specification_Is_Negated.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq.Expressions;
+
+namespace BkG.SpecificationPattern.Tests
+{
+    [TestClass]
+    public class Given_A_Single_Specification_Is_Negated
+    {
+        [TestMethod]
+        public void When_The_Restriction_Matched_Originally_Then_The_Specification_Is_Not_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+            var vNegatedSpecification = vSpecification.Not();
+
+            Assert.IsFalse(vNegatedSpecification.IsSatisfiedBy(true), "Restriction that originally tested true should not satisfy the negation");
+        }
+
+        [TestMethod]
+        public void When_The_Restriction_Did_Not_Match_Originally_Then_The_Specification_Is_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+            var vNegatedSpecification = vSpecification.Not();
+
+            Assert.IsTrue(vNegatedSpecification.IsSatisfiedBy(false), "Restriction that originally tested false should satisfy the negation");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_The_Restriction_Matched_Originally_Then_The_Specification_Is_Not_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+            var vNegatedSpecification = !vSpecification;
+
+            Assert.IsFalse(vNegatedSpecification.IsSatisfiedBy(true), "Restriction that originally tested true should not satisfy the negation");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_The_Restriction_Did_Not_Match_Originally_Then_The_Specification_Is_Satisfied()
+        {
+            var vSpecification = new Specification<bool>(testValue => testValue);
+            var vNegatedSpecification = !vSpecification;
+
+            Assert.IsTrue(vNegatedSpecification.IsSatisfiedBy(false), "Restriction that originally tested false should satisfy the negation");
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void Using_Overloaded_Operator_When_Spec_Is_Null_Then_Throws_Required_Argument_Null_Exception()
+        {
+            Specification<bool> vSpecification = null;
+            var vNegatedSpecification = !vSpecification;
+        }
+    }
+}

--- a/tests/BkG.SpecificationPattern.Tests/Given_Two_Specifications_Are_Joined_Using_And_Operation.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_Two_Specifications_Are_Joined_Using_And_Operation.cs
@@ -1,0 +1,108 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq.Expressions;
+
+namespace BkG.SpecificationPattern.Tests
+{
+    [TestClass]
+    public class Given_Two_Specifications_Are_Joined_Using_And_Operation
+    {
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void When_The_Other_Spec_Is_Null_Then_Required_Argument_Null_Exception_Is_Thrown()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            Specification<bool> vRight = null;
+
+            var vLeftAndRight = vLeft.And(vRight);
+        }
+
+        [TestMethod]
+        public void When_Both_Specifications_Are_Satisfied_Then_The_And_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !!testValue);
+
+            var vLeftAndRight = vLeft.And(vRight);
+            var vRightAndLeft = vRight.And(vLeft);
+
+            Assert.IsTrue(vLeftAndRight.IsSatisfiedBy(true), "When both original specifications are satisfied, then the AND operation should be as well.");
+            Assert.IsTrue(vRightAndLeft.IsSatisfiedBy(true), "When both original specifications are satisfied, then the AND operation should be as well.");
+        }
+
+        [TestMethod]
+        public void When_One_Specification_Is_Not_Satisfied_Then_The_And_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftAndRight = vLeft.And(vRight);
+            var vRightAndLeft = vRight.And(vLeft);
+
+            Assert.IsFalse(vLeftAndRight.IsSatisfiedBy(true), "When one specification is not satisfied, then the AND operation should not be as well.");
+            Assert.IsFalse(vRightAndLeft.IsSatisfiedBy(true), "When one specification is not satisfied, then the AND operation should not be as well.");
+        }
+
+        [TestMethod]
+        public void When_Neither_Specifications_Is_Satisfied_Then_The_And_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => !testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftAndRight = vLeft.And(vRight);
+            var vRightAndLeft = vRight.And(vLeft);
+
+            Assert.IsFalse(vLeftAndRight.IsSatisfiedBy(true), "When both specifications are not satisfied, then the AND operation should not be as well.");
+            Assert.IsFalse(vRightAndLeft.IsSatisfiedBy(true), "When both specifications are not satisfied, then the AND operation should not be as well.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void Using_Overloaded_Operator_When_This_Spec_Is_Null_Then_Required_Argument_Null_Exception_Is_Thrown()
+        {
+            Specification<bool> vLeft = null;
+            var vRight = new Specification<bool>(testValue => testValue);
+
+            var vLeftAndRight = vLeft & vRight;
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_Both_Specifications_Are_Satisfied_Then_The_And_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !!testValue);
+
+            var vLeftAndRight = vLeft & vRight;
+            var vRightAndLeft = vRight & vLeft;
+
+            Assert.IsTrue(vLeftAndRight.IsSatisfiedBy(true), "When both original specifications are satisfied, then the AND operation should be as well.");
+            Assert.IsTrue(vRightAndLeft.IsSatisfiedBy(true), "When both original specifications are satisfied, then the AND operation should be as well.");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_One_Specification_Is_Not_Satisfied_Then_The_And_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftAndRight = vLeft & vRight;
+            var vRightAndLeft = vRight & vLeft;
+
+            Assert.IsFalse(vLeftAndRight.IsSatisfiedBy(true), "When one specification is not satisfied, then the AND operation should not be as well.");
+            Assert.IsFalse(vRightAndLeft.IsSatisfiedBy(true), "When one specification is not satisfied, then the AND operation should not be as well.");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_Neither_Specifications_Is_Satisfied_Then_The_And_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => !testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftAndRight = vLeft & vRight;
+            var vRightAndLeft = vRight & vLeft;
+
+            Assert.IsFalse(vLeftAndRight.IsSatisfiedBy(true), "When both specifications are not satisfied, then the AND operation should not be as well.");
+            Assert.IsFalse(vRightAndLeft.IsSatisfiedBy(true), "When both specifications are not satisfied, then the AND operation should not be as well.");
+        }
+    }
+}

--- a/tests/BkG.SpecificationPattern.Tests/Given_Two_Specifications_Are_Joined_Using_Or_Operation.cs
+++ b/tests/BkG.SpecificationPattern.Tests/Given_Two_Specifications_Are_Joined_Using_Or_Operation.cs
@@ -1,0 +1,108 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq.Expressions;
+
+namespace BkG.SpecificationPattern.Tests
+{
+    [TestClass]
+    public class Given_Two_Specifications_Are_Joined_Using_Or_Operation
+    {
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void When_The_Other_Spec_Is_Null_Then_Required_Argument_Null_Exception_Is_Thrown()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            Specification<bool> vRight = null;
+
+            var vLeftOrRight = vLeft.Or(vRight);
+        }
+
+        [TestMethod]
+        public void When_Neither_Specifications_Is_Satisfied_Then_The_Or_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => !testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftOrRight = vLeft.Or(vRight);
+            var vRightOrLeft = vRight.Or(vLeft);
+
+            Assert.IsFalse(vRightOrLeft.IsSatisfiedBy(true), "When neither original specification is satisfied, then the OR operation should not be as well.");
+            Assert.IsFalse(vLeftOrRight.IsSatisfiedBy(true), "When neither original specification is satisfied, then the OR operation should not be as well.");
+        }
+
+        [TestMethod]
+        public void When_One_Specification_Is_Satisfied_Then_The_Or_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftOrRight = vLeft.Or(vRight);
+            var vRightOrLeft = vRight.Or(vLeft);
+
+            Assert.IsTrue(vLeftOrRight.IsSatisfiedBy(true), "When one specification is satisfied, then the OR operation should be as well.");
+            Assert.IsTrue(vRightOrLeft.IsSatisfiedBy(true), "When one specification is satisfied, then the OR operation should be as well.");
+        }
+
+        [TestMethod]
+        public void When_Both_Specifications_Is_Satisfied_Then_The_Or_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => testValue);
+
+            var vLeftOrRight = vLeft.Or(vRight);
+            var vRightOrLeft = vRight.Or(vLeft);
+
+            Assert.IsTrue(vLeftOrRight.IsSatisfiedBy(true), "When both specifications are satisfied, then the OR operation should be as well.");
+            Assert.IsTrue(vRightOrLeft.IsSatisfiedBy(true), "When both specifications are satisfied, then the OR operation should be as well.");
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(RequiredArgumentNullException))]
+        public void Using_Overloaded_Operator_When_This_Spec_Is_Null_Then_Required_Argument_Null_Exception_Is_Thrown()
+        {
+            Specification<bool> vLeft = null;
+            var vRight = new Specification<bool>(testValue => testValue);
+
+            var vLeftOrRight = vLeft | vRight;
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_Neither_Specifications_Is_Satisfied_Then_The_Or_Operation_Is_Not_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => !testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftOrRight = vLeft | vRight;
+            var vRightOrLeft = vRight | vLeft;
+
+            Assert.IsFalse(vRightOrLeft.IsSatisfiedBy(true), "When neither original specification is satisfied, then the OR operation should not be as well.");
+            Assert.IsFalse(vLeftOrRight.IsSatisfiedBy(true), "When neither original specification is satisfied, then the OR operation should not be as well.");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_One_Specification_Is_Satisfied_Then_The_Or_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => !testValue);
+
+            var vLeftOrRight = vLeft | vRight;
+            var vRightOrLeft = vRight | vLeft;
+
+            Assert.IsTrue(vLeftOrRight.IsSatisfiedBy(true), "When one specification is satisfied, then the OR operation should be as well.");
+            Assert.IsTrue(vRightOrLeft.IsSatisfiedBy(true), "When one specification is satisfied, then the OR operation should be as well.");
+        }
+
+        [TestMethod]
+        public void Using_Overloaded_Operator_When_Both_Specifications_Is_Satisfied_Then_The_Or_Operation_Is_Satisfied()
+        {
+            var vLeft = new Specification<bool>(testValue => testValue);
+            var vRight = new Specification<bool>(testValue => testValue);
+
+            var vLeftOrRight = vLeft | vRight;
+            var vRightOrLeft = vRight | vLeft;
+
+            Assert.IsTrue(vLeftOrRight.IsSatisfiedBy(true), "When both specifications are satisfied, then the OR operation should be as well.");
+            Assert.IsTrue(vRightOrLeft.IsSatisfiedBy(true), "When both specifications are satisfied, then the OR operation should be as well.");
+        }
+    }
+}


### PR DESCRIPTION
Supported logic operations with their respective overloaded operators

 + AND &
 + OR |
 + NOT !

Verify specification is met by using `IsSatisfiedBy` function

Implicit conversion back to `Expression` is supported

`Specification` itself should be immutable