### PR TITLE
Removes Invoke Calls In Binary Operations

### DIFF
--- a/src/BkG.SpecificationPattern/BinaryExpressionVisitor.cs
+++ b/src/BkG.SpecificationPattern/BinaryExpressionVisitor.cs
@@ -1,0 +1,19 @@
+using System.Linq.Expressions;
+
+namespace BkG.SpecificationPattern
+{
+    internal class BinaryExpressionVisitor : ExpressionVisitor
+    {
+        public BinaryExpressionVisitor(Expression left, Expression right)
+        {
+            _left = left;
+            _right = right;
+        }
+
+        public override Expression Visit(Expression node) => 
+            node == _left ? _right : base.Visit(node);
+
+        private readonly Expression _left;
+        private readonly Expression _right;
+    }
+}

--- a/src/BkG.SpecificationPattern/Specification.cs
+++ b/src/BkG.SpecificationPattern/Specification.cs
@@ -8,7 +8,9 @@ namespace BkG.SpecificationPattern
         public Specification(Expression<Func<T, bool>> restriction)
         {
             _restriction = restriction
-                            ?? throw new RequiredArgumentNullException(nameof(restriction), "The specification requires knowing what condition is to be met.");
+                            ?? throw new RequiredArgumentNullException(
+                                nameof(restriction), 
+                                "The specification requires knowing what condition is to be met.");
         }
 
         public bool IsSatisfiedBy(T current) => _restriction.Compile()(current);
@@ -20,29 +22,51 @@ namespace BkG.SpecificationPattern
                 Expression.Lambda<Func<T, bool>>(Expression.Not(_restriction.Body), _restriction.Parameters));
 
         public static Specification<T> operator !(Specification<T> specification) =>
-            specification?.Not() ?? throw new RequiredArgumentNullException(nameof(specification), "Negating specification requires non-null reference");
+            specification?.Not() 
+            ?? throw new RequiredArgumentNullException(
+                nameof(specification), 
+                "Negating specification requires non-null reference");
 
-        public Specification<T> And(Specification<T> other) => 
-            other != null
-                    ? DoBinaryOperation(this, other, ExpressionType.AndAlso)
-                    : throw new RequiredArgumentNullException(nameof(other), "The other operand for an And statement cannot be null");
+        public Specification<T> And(Specification<T> other) => DoBinaryOperation(Expression.AndAlso, this, other, "and");
 
         public static Specification<T> operator &(Specification<T> specification, Specification<T> other) =>
-            specification?.And(other) ?? throw new RequiredArgumentNullException(nameof(specification), "The first operand for an And statement cannot be null");
+            specification?.And(other) 
+            ?? throw new RequiredArgumentNullException(
+                nameof(specification), 
+                "The first operand for an And statement cannot be null");
 
-        public Specification<T> Or(Specification<T> other) => 
-            other != null
-                    ? DoBinaryOperation(this, other, ExpressionType.OrElse)
-                    : throw new RequiredArgumentNullException(nameof(other), "The other operand for an Or statement cannot be null");
+        public Specification<T> Or(Specification<T> other) => DoBinaryOperation(Expression.OrElse, this, other, "or");
 
         public static Specification<T> operator |(Specification<T> specification, Specification<T> other) =>
-            specification?.Or(other) ?? throw new RequiredArgumentNullException(nameof(specification), "The first operand for an Or statement cannot be null");
+            specification?.Or(other) 
+            ?? throw new RequiredArgumentNullException(
+                nameof(specification), 
+                "The first operand for an Or statement cannot be null");
 
-        private Specification<T> DoBinaryOperation(Specification<T> left, Specification<T> right, ExpressionType expressionType)
+        private Specification<T> DoBinaryOperation(
+                Func<Expression, Expression, BinaryExpression> operation,
+                Specification<T> left,
+                Specification<T> right,
+                string operationType
+            )
         {
-            var vRightInvoked = Expression.Invoke(right._restriction, left._restriction.Parameters);
-            var vBinaryExpression = Expression.MakeBinary(expressionType, left._restriction.Body, vRightInvoked);
-            return new Specification<T>(Expression.Lambda<Func<T, bool>>(vBinaryExpression, left._restriction.Parameters));
+            if(right == null)
+            {
+                throw new RequiredArgumentNullException(
+                    nameof(right), 
+                    $"The other operand for an '{operationType}' statement cannot be null");
+            }
+
+            var vExpression = Expression.Lambda<Func<T, bool>>(
+                operation(
+                    new BinaryExpressionVisitor(
+                            left._restriction.Parameters[0], right._restriction.Parameters[0]).Visit(left._restriction.Body),
+                            right._restriction.Body
+                        ),
+                    right._restriction.Parameters
+                );
+
+            return new Specification<T>(vExpression);
         }
 
         private readonly Expression<Func<T, bool>> _restriction;


### PR DESCRIPTION
Uses an Expression Visitor instead. Most likely to help compatability with Entity Framework.